### PR TITLE
Use conventional scope-names for `begin`/`end` rules

### DIFF
--- a/grammars/rtf.cson
+++ b/grammars/rtf.cson
@@ -6,14 +6,14 @@ patterns: [
   {
     begin: "\\{\\\\\\*"
     end:   "}"
-    beginCaptures: 0: name: "keyword.operator.begin-ignorable-destination-group.rtf"
-    endCaptures:   0: name: "keyword.operator.end-ignorable-destination-group.rtf"
+    beginCaptures: 0: name: "keyword.operator.group.ignorable-destination.begin.rtf"
+    endCaptures:   0: name: "keyword.operator.group.ignorable-destination.end.rtf"
     patterns: [include: "$self"]
   },{
     begin: "\\{"
     end:   "}"
-    beginCaptures: 0: name: "keyword.operator.begin-group.rtf"
-    endCaptures:   0: name: "keyword.operator.end-group.rtf"
+    beginCaptures: 0: name: "keyword.operator.group.begin.rtf"
+    endCaptures:   0: name: "keyword.operator.group.end.rtf"
     patterns: [include: "$self"]
   },{
     name:  "constant.character.escape.rtf"

--- a/grammars/rtf.cson
+++ b/grammars/rtf.cson
@@ -1,4 +1,4 @@
-"name": "RTF"
+name: "Rich Text Format"
 scopeName: "text.rtf"
 fileTypes: ["rtf"]
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "language-rtf",
   "version": "0.1.3",
-  "description": "RTF support for Pulsar and other Atom forks",
+  "description": "RTF (Rich Text File) support for Pulsar and other Atom forks",
   "keywords": [
-    "RTF"
+    "RTF",
+    "rich text"
   ],
   "repository": "https://github.com/nwhetsell/language-rtf",
   "license": "MIT",

--- a/spec/language-rtf-spec.js
+++ b/spec/language-rtf-spec.js
@@ -19,11 +19,11 @@ describe("language-rtf", () => {
     it("tokenizes groups", () => {
       const {tokens} = grammar.tokenizeLine("{}{\\*\\foo}");
       expect(tokens.length).toBe(5);
-      expect(tokens[0]).toEqual({value: "{", scopes: ["text.rtf", "keyword.operator.begin-group.rtf"]});
-      expect(tokens[1]).toEqual({value: "}", scopes: ["text.rtf", "keyword.operator.end-group.rtf"]});
-      expect(tokens[2]).toEqual({value: "{\\*", scopes: ["text.rtf", "keyword.operator.begin-ignorable-destination-group.rtf"]});
+      expect(tokens[0]).toEqual({value: "{", scopes: ["text.rtf", "keyword.operator.group.begin.rtf"]});
+      expect(tokens[1]).toEqual({value: "}", scopes: ["text.rtf", "keyword.operator.group.end.rtf"]});
+      expect(tokens[2]).toEqual({value: "{\\*", scopes: ["text.rtf", "keyword.operator.group.ignorable-destination.begin.rtf"]});
       expect(tokens[3]).toEqual({value: "\\foo", scopes: ["text.rtf", "support.function.rtf"]});
-      expect(tokens[4]).toEqual({value: "}", scopes: ["text.rtf", "keyword.operator.end-ignorable-destination-group.rtf"]});
+      expect(tokens[4]).toEqual({value: "}", scopes: ["text.rtf", "keyword.operator.group.ignorable-destination.end.rtf"]});
     });
 
     it("tokenizes control symbols", () => {
@@ -51,32 +51,32 @@ describe("language-rtf", () => {
       `);
       let tokens = lines[0];
       expect(tokens.length).toBe(14);
-      expect(tokens[0]).toEqual({value: "{", scopes: ["text.rtf", "keyword.operator.begin-group.rtf"]});
+      expect(tokens[0]).toEqual({value: "{", scopes: ["text.rtf", "keyword.operator.group.begin.rtf"]});
       expect(tokens[1]).toEqual({value: "\\rtf", scopes: ["text.rtf", "support.function.rtf"]});
       expect(tokens[2]).toEqual({value: "1", scopes: ["text.rtf", "constant.numeric.rtf"]});
       expect(tokens[3]).toEqual({value: "\\ansi", scopes: ["text.rtf", "support.function.rtf"]});
-      expect(tokens[4]).toEqual({value: "{", scopes: ["text.rtf", "keyword.operator.begin-group.rtf"]});
+      expect(tokens[4]).toEqual({value: "{", scopes: ["text.rtf", "keyword.operator.group.begin.rtf"]});
       expect(tokens[5]).toEqual({value: "\\fonttbl", scopes: ["text.rtf", "support.function.rtf"]});
       expect(tokens[6]).toEqual({value: "\\f", scopes: ["text.rtf", "support.function.rtf"]});
       expect(tokens[7]).toEqual({value: "0", scopes: ["text.rtf", "constant.numeric.rtf"]});
       expect(tokens[8]).toEqual({value: "\\fswiss", scopes: ["text.rtf", "support.function.rtf"]});
       expect(tokens[9]).toEqual({value: " Helvetica;", scopes: ["text.rtf"]});
-      expect(tokens[10]).toEqual({value: "}", scopes: ["text.rtf", "keyword.operator.end-group.rtf"]});
+      expect(tokens[10]).toEqual({value: "}", scopes: ["text.rtf", "keyword.operator.group.end.rtf"]});
       expect(tokens[11]).toEqual({value: "\\f", scopes: ["text.rtf", "support.function.rtf"]});
       expect(tokens[12]).toEqual({value: "0", scopes: ["text.rtf", "constant.numeric.rtf"]});
       expect(tokens[13]).toEqual({value: "\\pard", scopes: ["text.rtf", "support.function.rtf"]});
       tokens = lines[1];
       expect(tokens.length).toBe(7);
       expect(tokens[0]).toEqual({value: "This is some ", scopes: ["text.rtf"]});
-      expect(tokens[1]).toEqual({value: "{", scopes: ["text.rtf", "keyword.operator.begin-group.rtf"]});
+      expect(tokens[1]).toEqual({value: "{", scopes: ["text.rtf", "keyword.operator.group.begin.rtf"]});
       expect(tokens[2]).toEqual({value: "\\b", scopes: ["text.rtf", "support.function.rtf"]});
       expect(tokens[3]).toEqual({value: " bold", scopes: ["text.rtf", "markup.bold.rtf"]});
-      expect(tokens[4]).toEqual({value: "}", scopes: ["text.rtf", "keyword.operator.end-group.rtf"]});
+      expect(tokens[4]).toEqual({value: "}", scopes: ["text.rtf", "keyword.operator.group.end.rtf"]});
       expect(tokens[5]).toEqual({value: " text.", scopes: ["text.rtf"]});
       expect(tokens[6]).toEqual({value: "\\par", scopes: ["text.rtf", "support.function.rtf"]});
       tokens = lines[2];
       expect(tokens.length).toBe(1);
-      expect(tokens[0]).toEqual({value: "}", scopes: ["text.rtf", "keyword.operator.end-group.rtf"]});
+      expect(tokens[0]).toEqual({value: "}", scopes: ["text.rtf", "keyword.operator.group.end.rtf"]});
     });
 
     it("tokenizes property changes", () => {
@@ -89,7 +89,7 @@ describe("language-rtf", () => {
       `);
       let tokens = lines[0];
       expect(tokens.length).toBe(9);
-      expect(tokens[0]).toEqual({value: "{", scopes: ["text.rtf", "keyword.operator.begin-group.rtf"]});
+      expect(tokens[0]).toEqual({value: "{", scopes: ["text.rtf", "keyword.operator.group.begin.rtf"]});
       expect(tokens[1]).toEqual({value: "\\b", scopes: ["text.rtf", "support.function.rtf"]});
       expect(tokens[2]).toEqual({value: " bold ", scopes: ["text.rtf", "markup.bold.rtf"]});
       expect(tokens[3]).toEqual({value: "\\i", scopes: ["text.rtf", "markup.bold.rtf", "support.function.rtf"]});
@@ -97,21 +97,21 @@ describe("language-rtf", () => {
       expect(tokens[5]).toEqual({value: "\\i", scopes: ["text.rtf", "markup.bold.rtf", "support.function.rtf"]});
       expect(tokens[6]).toEqual({value: "0", scopes: ["text.rtf", "markup.bold.rtf", "constant.numeric.rtf"]});
       expect(tokens[7]).toEqual({value: " Bold again", scopes: ["text.rtf", "markup.bold.rtf"]});
-      expect(tokens[8]).toEqual({value: "}", scopes: ["text.rtf", "keyword.operator.end-group.rtf"]});
+      expect(tokens[8]).toEqual({value: "}", scopes: ["text.rtf", "keyword.operator.group.end.rtf"]});
       tokens = lines[1];
       expect(tokens.length).toBe(9);
-      expect(tokens[0]).toEqual({value: "{", scopes: ["text.rtf", "keyword.operator.begin-group.rtf"]});
+      expect(tokens[0]).toEqual({value: "{", scopes: ["text.rtf", "keyword.operator.group.begin.rtf"]});
       expect(tokens[1]).toEqual({value: "\\b", scopes: ["text.rtf", "support.function.rtf"]});
       expect(tokens[2]).toEqual({value: " bold ", scopes: ["text.rtf", "markup.bold.rtf"]});
-      expect(tokens[3]).toEqual({value: "{", scopes: ["text.rtf", "markup.bold.rtf", "keyword.operator.begin-group.rtf"]});
+      expect(tokens[3]).toEqual({value: "{", scopes: ["text.rtf", "markup.bold.rtf", "keyword.operator.group.begin.rtf"]});
       expect(tokens[4]).toEqual({value: "\\i", scopes: ["text.rtf", "markup.bold.rtf", "support.function.rtf"]});
       expect(tokens[5]).toEqual({value: " Bold Italic ", scopes: ["text.rtf", "markup.bold.rtf", "markup.italic.rtf"]});
-      expect(tokens[6]).toEqual({value: "}", scopes: ["text.rtf", "markup.bold.rtf", "keyword.operator.end-group.rtf"]});
+      expect(tokens[6]).toEqual({value: "}", scopes: ["text.rtf", "markup.bold.rtf", "keyword.operator.group.end.rtf"]});
       expect(tokens[7]).toEqual({value: "Bold again", scopes: ["text.rtf", "markup.bold.rtf"]});
-      expect(tokens[8]).toEqual({value: "}", scopes: ["text.rtf", "keyword.operator.end-group.rtf"]});
+      expect(tokens[8]).toEqual({value: "}", scopes: ["text.rtf", "keyword.operator.group.end.rtf"]});
       tokens = lines[2];
       expect(tokens.length).toBe(9);
-      expect(tokens[0]).toEqual({value: "{", scopes: ["text.rtf", "keyword.operator.begin-group.rtf"]});
+      expect(tokens[0]).toEqual({value: "{", scopes: ["text.rtf", "keyword.operator.group.begin.rtf"]});
       expect(tokens[1]).toEqual({value: "\\b", scopes: ["text.rtf", "support.function.rtf"]});
       expect(tokens[2]).toEqual({value: " bold ", scopes: ["text.rtf", "markup.bold.rtf"]});
       expect(tokens[3]).toEqual({value: "\\i", scopes: ["text.rtf", "markup.bold.rtf", "support.function.rtf"]});
@@ -119,20 +119,20 @@ describe("language-rtf", () => {
       expect(tokens[5]).toEqual({value: "\\plain", scopes: ["text.rtf", "support.function.rtf"]});
       expect(tokens[6]).toEqual({value: "\\b", scopes: ["text.rtf", "support.function.rtf"]});
       expect(tokens[7]).toEqual({value: " Bold again", scopes: ["text.rtf", "markup.bold.rtf"]});
-      expect(tokens[8]).toEqual({value: "}", scopes: ["text.rtf", "keyword.operator.end-group.rtf"]});
+      expect(tokens[8]).toEqual({value: "}", scopes: ["text.rtf", "keyword.operator.group.end.rtf"]});
     });
 
     it("tokenizes property changes without spaces", () => {
       // https://github.com/nwhetsell/language-rtf/issues/1
       const {tokens} = grammar.tokenizeLine("{\\b bold \\b0not bold}");
       expect(tokens.length).toBe(7);
-      expect(tokens[0]).toEqual({value: "{", scopes: ["text.rtf", "keyword.operator.begin-group.rtf"]});
+      expect(tokens[0]).toEqual({value: "{", scopes: ["text.rtf", "keyword.operator.group.begin.rtf"]});
       expect(tokens[1]).toEqual({value: "\\b", scopes: ["text.rtf", "support.function.rtf"]});
       expect(tokens[2]).toEqual({value: " bold ", scopes: ["text.rtf", "markup.bold.rtf"]});
       expect(tokens[3]).toEqual({value: "\\b", scopes: ["text.rtf", "support.function.rtf"]});
       expect(tokens[4]).toEqual({value: "0", scopes: ["text.rtf", "constant.numeric.rtf"]});
       expect(tokens[5]).toEqual({value: "not bold", scopes: ["text.rtf"]});
-      expect(tokens[6]).toEqual({value: "}", scopes: ["text.rtf", "keyword.operator.end-group.rtf"]});
+      expect(tokens[6]).toEqual({value: "}", scopes: ["text.rtf", "keyword.operator.group.end.rtf"]});
     });
   });
 });


### PR DESCRIPTION
TextMate's scope naming conventions generally prescribe the use of `begin` and `end` scopes to identify the opening and closing patterns of a multiline grammar rule:

~~~cson
name:  "meta.group"
begin: "{"
end:   "}"
beginCaptures: 0: "punctuation.definition.group.begin"
endCaptures:   0: "punctuation.definition.group.end"
~~~

This facilitates recognition of "paired" characters in certain text-editing features, and some syntax themes style tokens that include `begin` and `end` scopes to make their colour more noticeable.

In short, none of these benefits are applying to the current RTF grammar, which uses the following overly-specific scopes:

~~~cson
beginCaptures: 0: name: "keyword.operator.begin-ignorable-destination-group.rtf"
endCaptures:   0: name: "keyword.operator.end-ignorable-destination-group.rtf"
~~~

This PR breaks the scope lists down into more atomic and well-known names, and reorders them for the benefit of TextMate users who might be using a conversion of this package (unlikely, but possible). If you're curious why this matters, go [here](https://github.com/Alhadis/Atom-GitHubSyntax?tab=readme-ov-file#textmate-vs-css) for the gory details.